### PR TITLE
Remove \r with universal newline scheme when emitting YAML

### DIFF
--- a/jenkins-jobcfg.py
+++ b/jenkins-jobcfg.py
@@ -60,8 +60,11 @@ except ImportError as e:
 # ####################################################################
 
 def xml2yaml(in_str):
+    def universal_newlines(x):
+        return x.replace('\r\n', '\n').replace('\r', '\n')
     return xmlplain.obj_to_yaml(
-        xmlplain.xml_to_obj(in_str, strip_space=True, fold_dict=True))
+        xmlplain.xml_to_obj(in_str, strip_space=True, fold_dict=True),
+        process_string=universal_newlines)
 
 def yaml2xml(in_str):
     return xmlplain.xml_from_obj(xmlplain.obj_from_yaml(in_str),

--- a/jenkins-jobcfg.py
+++ b/jenkins-jobcfg.py
@@ -27,7 +27,7 @@
 #
 # For more information, please refer to <https://unlicense.org>
 
-import sys, os, re, getpass, json, collections, warnings, base64, StringIO
+import sys, os, re, getpass, json, collections, warnings, base64
 import contextlib
 
 try:
@@ -61,15 +61,11 @@ except ImportError as e:
 
 def xml2yaml(in_str):
     return xmlplain.obj_to_yaml(
-        xmlplain.xml_to_obj(
-            StringIO.StringIO(in_str), strip_space=True, fold_dict=True))
+        xmlplain.xml_to_obj(in_str, strip_space=True, fold_dict=True))
 
 def yaml2xml(in_str):
-    with contextlib.closing(StringIO.StringIO()) as outf:
-        xmlplain.xml_from_obj(
-            xmlplain.obj_from_yaml(StringIO.StringIO(in_str)),
-            outf=outf, pretty=True)
-        return outf.getvalue()
+    return xmlplain.xml_from_obj(xmlplain.obj_from_yaml(in_str),
+                                 outf=None, pretty=True)
 
 
 # ####################################################################


### PR DESCRIPTION
Restore former behavior, removing all \r when outputting YAML in order to have human editable YAML files.
There do not seem to be a better solution as actually the issue comes from Jenkins not managing universal newlines and thus emitting "quoted '\r'", (i.e. the input contains '&#xd;) when creating XML configuration file.
Removing '\r' with universal newline scheme seems reasonable as it is the same effect as reading/writing and reading again an XML with non-quoted '\r' with a XML parser such as xmlint.
